### PR TITLE
Knapp for toggling av kart-/flyfotovisning

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -255,6 +255,12 @@ a {
     font-weight: 400;
 }
 
+.smallicon {
+    font-size: 18px;
+    font-weight: 600;
+    display: inline-block;
+}
+
 .icon {
     font-size: 32px;
     font-weight: 600;


### PR DESCRIPTION
Flyfoto toggle. Kilde Geonorge. Åpnet opp pga corona, ref. [Geonorge](https://register.geonorge.no/inspire-statusregister/norge-i-bilder-wms-ortofoto/dcee8bf4-fdf3-4433-a91b-209c7d9b0b0f?InspireRegisteryType=service) (riktignok uavklart varighet).